### PR TITLE
Use the correct headers for link collections

### DIFF
--- a/k4GaudiPandora/src/DDMCParticleCreator.cc
+++ b/k4GaudiPandora/src/DDMCParticleCreator.cc
@@ -27,8 +27,8 @@
 
 #include "edm4hep/CaloHitContribution.h"
 #include "edm4hep/MCParticle.h"
-#include "edm4hep/MCRecoCaloAssociation.h"
-#include "edm4hep/MCRecoTrackerAssociation.h"
+#include "edm4hep/CaloHitSimCaloHitLinkCollection.h"
+#include "edm4hep/TrackerHitSimTrackerHitLinkCollection.h"
 #include "edm4hep/SimCalorimeterHit.h"
 #include "edm4hep/SimTrackerHit.h"
 #include "edm4hep/Track.h"


### PR DESCRIPTION
Use the correct headers for links instead of the deprecated old ones that have been removed in https://github.com/key4hep/EDM4hep/pull/373